### PR TITLE
Simplify test for callable

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -156,7 +156,7 @@ class Container implements \ArrayAccess
      */
     public function factory($callable)
     {
-        if (!is_object($callable) || !method_exists($callable, '__invoke')) {
+        if (!method_exists($callable, '__invoke')) {
             throw new \InvalidArgumentException('Service definition is not a Closure or invokable object.');
         }
 
@@ -178,7 +178,7 @@ class Container implements \ArrayAccess
      */
     public function protect($callable)
     {
-        if (!is_object($callable) || !method_exists($callable, '__invoke')) {
+        if (!method_exists($callable, '__invoke')) {
             throw new \InvalidArgumentException('Callable is not a Closure or invokable object.');
         }
 


### PR DESCRIPTION
- Closures and other objects implementing __invoke are callable
- Function method_exists accepts any 'object' parameter
- Strong typing is coming in php7 for objects